### PR TITLE
Fixed for previously unset SELF_URL_PATH

### DIFF
--- a/setup-ttrss.sh
+++ b/setup-ttrss.sh
@@ -43,7 +43,7 @@ setup_ttrss()
     cp ${TTRSS_PATH}/config.php-dist ${TTRSS_PATH}/config.php
 
     # Patch URL path.
-    sed -i -e 's@http://localhost/@'"$SELF_URL_PATH"'@g' ${TTRSS_PATH}/config.php
+    sed -i -e 's@htt.*/@'"${SELF_URL_PATH-http://localhost/}"'@g' ${TTRSS_PATH}/config.php
 
     # Enable additional system plugins: api_newsplus.
     sed -i -e "s/.*define('PLUGINS'.*/define('PLUGINS', 'api_newsplus, auth_internal, note, updater');/g" ${TTRSS_PATH}/config.php


### PR DESCRIPTION
This now uses http://localhost/ as default SELF_PATH_URL if this is not set and properly sets it's value if an env variable is passed to the container.

Sorry for the previous bad PR :disappointed: 