### PR TITLE
Fix port setting

### DIFF
--- a/root/srv/setup-ttrss.sh
+++ b/root/srv/setup-ttrss.sh
@@ -73,22 +73,12 @@ setup_ttrss()
     
         # Make sure the TTRSS protocol is https now.
         TTRSS_PROTO=https
-
-        # Set the default https port if not specified otherwise.
-        if [ -z ${TTRSS_PORT} ]; then
-            TTRSS_PORT=:4443
-        fi
     fi
 
     # If no protocol is specified, use http as default. Not secure, I know.
     if [ -z ${TTRSS_PROTO} ]; then
         
         TTRSS_PROTO=http
-
-        # Set the default port if not specified otherwise.
-        if [ -z ${TTRSS_PORT} ]; then
-            TTRSS_PORT=:8080
-        fi        
     fi
       
     # Construct the final URL TTRSS will use.


### PR DESCRIPTION
This corrects the port setting introduced in commit ecd2c19 (and
likely earlier). If a user does not specify a port, just use
the default ports and do not force setting one. By forcing it,
it breaks logging in via the web console.

Signed-off-by: Kyle Mestery <mestery@mestery.com>