### PR TITLE
Expose plugins.local and themes.local via Docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ ENV DB_NAME ttrss
 ENV DB_USER ttrss
 ENV DB_PASS ttrss
 
+# Expose volumes
+VOLUME [ "/var/www/ttrss-plugins", "/var/www/ttrss-themes" ]
+
 # Clean up.
 RUN set -xe && apk del --progress --purge && rm -rf /var/cache/apk/*
 

--- a/root/srv/setup-ttrss.sh
+++ b/root/srv/setup-ttrss.sh
@@ -57,6 +57,13 @@ setup_ttrss()
             echo "Setup: Setting up Tiny Tiny RSS (latest revision) ..."
             git clone --depth=1 https://tt-rss.org/gitlab/fox/tt-rss.git ${TTRSS_PATH}
         fi
+	# Move pristine directories (re-used for updates), create links to volume mounts
+	mkdir -p ${TTRSS_PATH}.orig ${TTRSS_PATH}.temp
+	mv ${TTRSS_PATH}/plugins.local ${TTRSS_PATH}/themes.local ${TTRSS_PATH}.orig/
+	mkdir -p ${TTRSS_PATH}-plugins ${TTRSS_PATH}-themes
+	ln -s ${TTRSS_PATH}-plugins ${TTRSS_PATH}/plugins.local
+	ln -s ${TTRSS_PATH}-themes ${TTRSS_PATH}/themes.local
+	# Clone default plugins / themes
         git clone --depth=1 https://github.com/sepich/tt-rss-mobilize.git ${TTRSS_PATH}/plugins/mobilize
         git clone --depth=1 https://github.com/hrk/tt-rss-newsplus-plugin.git ${TTRSS_PATH}/plugins/api_newsplus
         git clone --depth=1 https://github.com/m42e/ttrss_plugin-feediron.git ${TTRSS_PATH}/plugins/feediron

--- a/root/srv/update-ttrss.sh
+++ b/root/srv/update-ttrss.sh
@@ -10,7 +10,19 @@ update_ttrss()
     fi
 
     echo "Updating: Tiny Tiny RSS"
-    ( cd ${TTRSS_PATH} && git pull origin HEAD )
+    # Restore original files to avoid git conflicts
+    cd ${TTRSS_PATH}
+    mv plugins.local ${TTRSS_PATH}.temp/
+    mv ${TTRSS_PATH}.orig/plugins.local .
+    mv themes.local ${TTRSS_PATH}.temp/
+    mv ${TTRSS_PATH}.orig/themes.local .
+    # Update
+    git pull origin HEAD
+    # Switch back to links
+    mv plugins.local ${TTRSS_PATH}.orig/
+    mv ${TTRSS_PATH}.temp/plugins.local .
+    mv themes.local ${TTRSS_PATH}.orig/
+    mv ${TTRSS_PATH}.temp/themes.local .
 }
 
 update_plugin_mobilize()


### PR DESCRIPTION
Allow admins to install plugins and themes in a persistent manner (urgently required if you're automatically updating your Docker volumes via watchtower or similar) - mentioned in #9 :-)
Exposes two volumes; install and update process modified to keep original files from ttrss git repo to avoid conflicts during update.