### PR TITLE
double quotes to expand $DB_TYPE

### DIFF
--- a/root/etc/cont-init.d/98-wait-for-db
+++ b/root/etc/cont-init.d/98-wait-for-db
@@ -8,7 +8,7 @@
 ename='DB';
 eport=5432;
 
-if [ '$DB_TYPE' = 'mysql' ];
+if [ "$DB_TYPE" = 'mysql' ];
 then
 	eport=3306;
 	dbhost=$DB_PORT_3306_TCP_ADDR


### PR DESCRIPTION
Without that I get the following error with DB_TYPE=mysql : 
```Checking database responds within 1s on :5432...```