### PR TITLE
Adds missing php7 fileinfo extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -xe && \
     php7 php7-fpm php7-curl php7-dom php7-gd php7-iconv php7-json php7-mcrypt \
     php7-pgsql php7-pcntl php7-pdo php7-pdo_pgsql \
     php7-mysqli php7-pdo_mysql \
-    php7-mbstring php7-posix php7-session
+    php7-mbstring php7-posix php7-session php7-fileinfo
 
 # Add user www-data for php-fpm.
 # 82 is the standard uid/gid for "www-data" in Alpine.


### PR DESCRIPTION
In order to solve the startup issue with missing mime_content_type() function.

See: https://github.com/x86dev/docker-ttrss/issues/22