### PR TITLE
Add Fever API plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Dockerfile installs Tiny Tiny RSS (TT-RSS) with the following features:
 - Integrated [Feedly theme](https://github.com/levito/tt-rss-feedly-theme)
 - Integrated [FeedIron plugin](https://github.com/m42e/ttrss_plugin-feediron) to get modify feeds
 - Integrated [Mobilize plugin](https://github.com/sepich/tt-rss-mobilize) for using Readability, Instapaper + Google Mobilizer
+- Integrated [Fever API plugin](https://github.com/DigitalDJ/tinytinyrss-fever-plugin) to allow compatible RSS clients to use Tiny Tiny RSS.
 - Optional: Self-signed 4096-bit RSA TLS certificate for accessing TT-RSS via https
 - Originally was based on [clue/docker-ttrss](https://github.com/clue/docker-ttrss)
 

--- a/root/srv/setup-ttrss.sh
+++ b/root/srv/setup-ttrss.sh
@@ -66,6 +66,7 @@ setup_ttrss()
         git clone --depth=1 https://github.com/sepich/tt-rss-mobilize.git ${TTRSS_PATH}/plugins/mobilize
         git clone --depth=1 https://github.com/m42e/ttrss_plugin-feediron.git ${TTRSS_PATH}/plugins/feediron
         git clone --depth=1 https://github.com/levito/tt-rss-feedly-theme.git ${TTRSS_PATH}/themes/feedly-git
+        git clone --depth=1 https://github.com/DigitalDJ/tinytinyrss-fever-plugin ${TTRSS_PATH}/themes/fever
     fi
 
     # Add initial config.

--- a/root/srv/setup-ttrss.sh
+++ b/root/srv/setup-ttrss.sh
@@ -65,8 +65,8 @@ setup_ttrss()
         fi
         git clone --depth=1 https://github.com/sepich/tt-rss-mobilize.git ${TTRSS_PATH}/plugins/mobilize
         git clone --depth=1 https://github.com/m42e/ttrss_plugin-feediron.git ${TTRSS_PATH}/plugins/feediron
+        git clone --depth=1 https://github.com/DigitalDJ/tinytinyrss-fever-plugin ${TTRSS_PATH}/plugins/fever
         git clone --depth=1 https://github.com/levito/tt-rss-feedly-theme.git ${TTRSS_PATH}/themes/feedly-git
-        git clone --depth=1 https://github.com/DigitalDJ/tinytinyrss-fever-plugin ${TTRSS_PATH}/themes/fever
     fi
 
     # Add initial config.

--- a/root/srv/update-ttrss.sh
+++ b/root/srv/update-ttrss.sh
@@ -28,6 +28,12 @@ update_plugin_feediron()
     ( cd ${TTRSS_PATH}/plugins/feediron && git pull origin HEAD )
 }
 
+update_plugin_fever()
+{
+    echo "Updating: Fever API"
+    ( cd ${TTRSS_PATH}/plugins/fever && git pull origin HEAD )
+}
+
 update_theme_feedly()
 {
     echo "Updating: Feedly theme"
@@ -60,6 +66,7 @@ update_common()
 update_ttrss
 update_plugin_mobilize
 update_plugin_feediron
+update_plugin_fever
 update_theme_feedly
 update_common
 


### PR DESCRIPTION
Adds the [Fever API plugin](https://github.com/DigitalDJ/tinytinyrss-fever-plugin) to allow connections from clients that use this API. Must enable API access in tt-rss settings.