### PR TITLE
Add ENV var to allow skipping of self url path sanity checks when using a reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# docker-ttrss
+# docker-ttrss
 
 This Dockerfile installs Tiny Tiny RSS (TT-RSS) with the following features:
 
@@ -82,6 +82,8 @@ Docker container running on the same machine as this one.
 
 That way you easily can integrate your TT-RSS instance with an existing domain by using a sub domain
 (e.g. https://ttrss.yourdomain.tld).
+
+You can set the environment variable `TTRSS_SKIP_SELF_URL_PATH_CHECKS=1` (eg. `docker -e  TTRSS_SKIP_SELF_URL_PATH_CHECKS=1 ...`) if you get the error `Please set SELF_URL_PATH to the correct value detected for your server:` when accessing TT-RSS.
 
 ### Enabling SSL/TLS encryption support
 

--- a/root/srv/setup-ttrss.sh
+++ b/root/srv/setup-ttrss.sh
@@ -122,6 +122,13 @@ setup_ttrss()
         sed -i -e "s/.*define('SINGLE_USER_MODE'.*/define('SINGLE_USER_MODE', 'true');/g" ${TTRSS_PATH}/config.php
     fi
 
+    # Skip self url checks ("Please set SELF_URL_PATH to the correct value detected for your server:"). 
+    # Useful if using a reverse proxy
+    if [ -n "${TTRSS_SKIP_SELF_URL_PATH_CHECKS}" ]; then
+        echo "Setup: Skipping self url path checks"
+        echo "define('_SKIP_SELF_URL_PATH_CHECKS', true);" >> ${TTRSS_PATH}/config.php
+    fi
+
     # Enable additional system plugins.
     if [ -z ${TTRSS_PLUGINS} ]; then
 


### PR DESCRIPTION
This is useful if you have a reverse proxy infront of the TT-RSS docker container and you get the error
"Please set SELF_URL_PATH to the correct value detected for your server:" when accessing it.

When clicking an articles headline it expands to show a part of the actual article.
Clicking on the headline again should send me to the original article URL.
This is done by creating a new window and sending a POST to the URL set by the ENV var `TTRSS_SELF_URL` and friends.
But when setting this var TT-RSS will not start up anymore but show the dreaded error:
```
Please set SELF_URL_PATH to the correct value detected for your server: ....
```

This PR add a ENV variable `TTRSS_SKIP_SELF_URL_PATH_CHECKS`which disables the TT-RSS self url path sanity checks.