### PR TITLE
fix(Dockerfile): Fix permission issue for startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -xe && \
 RUN adduser -u 82 -D -S -G www-data www-data
 
 # Copy root file system.
-COPY root /
+COPY --chown=www-data:www-data root /
 
 # Add s6 overlay.
 #ARG S6_OVERLAY_VERSION=3.1.5.0


### PR DESCRIPTION
The startup script could not be started (in my case)  because of permission issues. Looking at the log, I saw:

```
rssreader                | [s6-init] making user provided files available at /var/run/s6/etc...exited 0.
rssreader                | [s6-init] ensuring user provided files have correct perms...exited 0.
rssreader                | [fix-attrs.d] applying ownership & permissions fixes...
rssreader                | [fix-attrs.d] done.
rssreader                | [cont-init.d] executing container initialization scripts...
rssreader                | [cont-init.d] 50-php: executing... 
rssreader                | [cont-init.d] 50-php: exited 0.
rssreader                | [cont-init.d] 98-wait-for-db: executing... 
rssreader                | Checking database responds within 1s on postgres:5432...
rssreader                | [cont-init.d] 98-wait-for-db: exited 0.
rssreader                | [cont-init.d] 99-ttrss: executing... 
rssreader                | /var/run/s6/etc/cont-init.d/99-ttrss: line 2: ./setup-ttrss.sh: Permission denied
rssreader                | [cont-init.d] 99-ttrss: exited 126.
rssreader                | [cont-init.d] done.
rssreader                | [services.d] starting services
rssreader                | ./run: cd: line 4: can't cd to /var/www/ttrss: No such file or directory
rssreader                | nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/nginx.conf:39
```

By passing `--chown`, we set the file owner to what s6 expects.